### PR TITLE
Payment/state not ready

### DIFF
--- a/alma/entities/payment.py
+++ b/alma/entities/payment.py
@@ -56,8 +56,8 @@ class Payment(Base):
                 self.state = PaymentState(state)
             except ValueError:
                 # Pass on unrecognized state values
-                # they will be accessible as-is in the Payment data
-                pass
+                # restore it in the raw Payment data so that it can still be retrieved
+                data["state"] = state
 
         orders = data.pop("orders", [])
         self.orders = [Order(o) for o in orders]

--- a/alma/entities/payment.py
+++ b/alma/entities/payment.py
@@ -7,6 +7,8 @@ from .refund import Refund
 
 
 class PaymentState(Enum):
+    # Payment has been created but its payment plan is not yet initialized
+    NOT_READY = "not_ready"
     # Payment was just created, not scored and nothing paid yet
     NOT_STARTED = "not_started"
     # Was scored and not accepted


### PR DESCRIPTION
- Add NOT_READY state to known states
- When state isn't recognized, make it available in `Payment.raw_data`