### PR TITLE
Configure credentials after request is fully built

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
 

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ flake8: install-dev
 	$(VENV)/bin/flake8 setup.py alma tests
 
 mypy: install-dev
-	$(VENV)/bin/mypy --ignore-missing-imports --scripts-are-modules alma
+	$(VENV)/bin/mypy --ignore-missing-imports --scripts-are-modules --implicit-optional alma
 
 build-requirements:
 	$(VIRTUALENV) $(TEMPDIR)

--- a/alma_client/async_client.py
+++ b/alma_client/async_client.py
@@ -9,14 +9,8 @@ from .response import Response
 
 
 async def process_request(req):
-    request = httpx.Request(
-        req.method,
-        req.url,
-        headers=req.headers,
-        cookies=req.cookies,
-        params=req.params,
-        json=req.body,
-    )
+
+    request = req.to_httpx()
     async with httpx.AsyncClient() as client:
         resp = await client.send(request)
 

--- a/alma_client/client.py
+++ b/alma_client/client.py
@@ -20,14 +20,8 @@ from .version import __version__ as alma_version
 
 
 def process_request(req):
-    request = httpx.Request(
-        req.method,
-        req.url,
-        headers=req.headers,
-        cookies=req.cookies,
-        params=req.params,
-        json=req.body,
-    )
+
+    request = req.to_httpx()
     with httpx.Client() as client:
         resp = client.send(request)
 

--- a/alma_client/request.py
+++ b/alma_client/request.py
@@ -1,4 +1,3 @@
-from functools import wraps
 import httpx
 import json
 
@@ -66,7 +65,7 @@ class Request:
 
     @property
     def data(self):
-      return json.dumps(self.body)
+        return json.dumps(self.body)
 
     def to_httpx(self):
         self.context.credentials.configure(self)

--- a/alma_client/request.py
+++ b/alma_client/request.py
@@ -70,7 +70,7 @@ class Request:
 
     def to_httpx(self):
         self.context.credentials.configure(self)
-        headers = dict(self.headers)
+        headers = self.headers.copy()
         headers["Content-Type"] = "application/json"
         req = httpx.Request(
             self.method,

--- a/alma_client/request.py
+++ b/alma_client/request.py
@@ -1,5 +1,6 @@
-import httpx
 import json
+
+import httpx
 
 from .paginated_results import PaginatedResults
 
@@ -69,10 +70,12 @@ class Request:
 
     def to_httpx(self):
         self.context.credentials.configure(self)
+        headers = dict(self.headers)
+        headers["Content-Type"] = "application/json"
         req = httpx.Request(
             self.method,
             self.url,
-            headers=self.headers | {'Content-Type': 'application/json'},
+            headers=headers,
             cookies=self.cookies,
             params=self.params,
             content=self.data,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ CHANGELOG = (HERE / "CHANGELOG.md").read_text()
 # This call to setup() does all the work
 setup(
     name="alma-client",
-    version="3.1.0.dev0",
+    version="3.2.0",
     description="Python API client for the Alma Installments API",
     long_description=f"{README}\n\n{CHANGELOG}",
     long_description_content_type="text/markdown",

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -10,20 +10,10 @@ class RequestTest(TestCase):
         self.credentials = client.context.credentials
         self.request = Request(client.context, "https://url.com")
 
-    def assert_method_calls_configure(self, method):
+    def test_credentials_configure_is_called_on_request_build(self):
         with mock.patch("alma_client.credentials.ApiKeyCredentials.configure") as mocked_configure:
-            getattr(self.request, method)()
+            self.request.get()
+            mocked_configure.assert_not_called()
+            # only upon building the httpx Req are the credentials configured
             _ = self.request.to_httpx()
             mocked_configure.assert_called_once_with(self.request)
-
-    def test_credentials_configure_is_called_on_get(self):
-        self.assert_method_calls_configure("get")
-
-    def test_credentials_configure_is_called_on_post(self):
-        self.assert_method_calls_configure("post")
-
-    def test_credentials_configure_is_called_on_put(self):
-        self.assert_method_calls_configure("put")
-
-    def test_credentials_configure_is_called_on_delete(self):
-        self.assert_method_calls_configure("delete")

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -13,6 +13,7 @@ class RequestTest(TestCase):
     def assert_method_calls_configure(self, method):
         with mock.patch("alma_client.credentials.ApiKeyCredentials.configure") as mocked_configure:
             getattr(self.request, method)()
+            req = self.request.to_httpx()
             mocked_configure.assert_called_once_with(self.request)
 
     def test_credentials_configure_is_called_on_get(self):

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -13,7 +13,7 @@ class RequestTest(TestCase):
     def assert_method_calls_configure(self, method):
         with mock.patch("alma_client.credentials.ApiKeyCredentials.configure") as mocked_configure:
             getattr(self.request, method)()
-            req = self.request.to_httpx()
+            _ = self.request.to_httpx()
             mocked_configure.assert_called_once_with(self.request)
 
     def test_credentials_configure_is_called_on_get(self):

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ python =
 
 [testenv]
 commands =
-    mypy --ignore-missing-imports --scripts-are-modules alma_client
+    mypy --ignore-missing-imports --scripts-are-modules --implicit-optional alma_client
     pytest tests --cov-report term-missing --cov alma_client {posargs} # --cov-fail-under 100
 deps =
     -rtest-requirements.txt


### PR DESCRIPTION
To allow a more flexible credential scheme, the configure() is called just before running the query.